### PR TITLE
Fix README to match actual CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,23 @@
 
 ## Features
 
-### 1. List Commands
+### 1. View Commands
 
-Access all your Things 3 lists with a single command:
+Access all your Things 3 lists directly:
 
 ```bash
-clings list              # Show today's todos (default)
-clings list inbox        # Show inbox
-clings list upcoming     # Show upcoming todos
-clings list areas        # List all areas
-clings list tags         # List all tags
-clings list projects     # List all projects
-
-# Shortcuts for common views
-clings today             # or: clings t
+clings today             # or: clings t (default command)
 clings inbox             # or: clings i
 clings upcoming          # or: clings u
+clings anytime
 clings someday           # or: clings s
 clings logbook           # or: clings l
+
+# Organization
+clings projects          # List all projects
+clings areas             # List all areas
+clings tags list         # List all tags
+clings show <ID>         # Show details of a specific todo
 ```
 
 ### 2. Natural Language Task Entry
@@ -54,28 +53,71 @@ clings add "review PR // needs careful testing - check auth - verify tests"
 # - Checklist: - item1 - item2
 ```
 
-### 3. Search with Filters
-
-Search your todos with simple flags or advanced SQL-like expressions:
+You can also use explicit flags:
 
 ```bash
-# Text search
-clings search "meeting"
+clings add "Task title" \
+  --when tomorrow \
+  --deadline "2024-12-31" \
+  --tags work urgent \
+  --project "Sprint 1" \
+  --area "Work" \
+  --notes "Additional context"
 
-# Filter by tag, project, or due date
-clings search --tag work
-clings search --project "Sprint 1"
-clings search --due today
-
-# Advanced filter (SQL-like syntax)
-clings search --filter "status = 'open' AND due < today"
-clings search --filter "tags CONTAINS 'urgent' OR project = 'Important'"
+# Preview without creating
+clings add "Test task tomorrow #work" --parse-only
 ```
 
-**Filter operators:** `=`, `!=`, `<`, `>`, `LIKE`, `CONTAINS`, `IS NULL`, `IS NOT NULL`, `IN`
-**Logic:** `AND`, `OR`, `NOT`, parentheses
+### 3. Search and Filter
 
-### 4. Bulk Operations
+Search todos by text, or use the powerful filter command for advanced queries:
+
+```bash
+# Text search (case-insensitive, searches title and notes)
+clings search "meeting"
+clings find "project report"     # alias for search
+clings f "status"                # short alias
+
+# Advanced filtering (SQL-like query language)
+clings filter "status = open"
+clings filter "due < today AND status = open"
+clings filter "tags CONTAINS 'urgent'"
+clings filter "name LIKE '%report%'"
+clings filter "project IS NOT NULL"
+```
+
+**Filter operators:** `=`, `!=`, `<`, `>`, `<=`, `>=`, `LIKE`, `CONTAINS`, `IS NULL`, `IS NOT NULL`, `IN`
+**Logic:** `AND`, `OR`
+**Fields:** `status`, `due`, `tags`, `project`, `area`, `name`, `notes`, `created`
+
+### 4. Todo Management
+
+Manage individual todos:
+
+```bash
+# Show details
+clings show <ID>
+
+# Update properties
+clings update <ID> --name "New title"
+clings update <ID> --notes "Updated notes"
+clings update <ID> --due 2024-12-25
+clings update <ID> --tags work urgent
+
+# Schedule and organize (requires auth token, see Configuration)
+clings update <ID> --when tomorrow
+clings update <ID> --heading "Waiting on them"
+clings update <ID> --when today --heading "In Progress"
+
+# Complete, cancel, or delete
+clings complete <ID>             # or: clings done <ID>
+clings complete --title "milk"   # complete by title search
+clings cancel <ID>
+clings delete <ID>               # or: clings rm <ID>
+clings delete <ID> --force       # skip confirmation
+```
+
+### 5. Bulk Operations
 
 Perform operations on multiple tasks using powerful filters.
 
@@ -100,42 +142,29 @@ clings bulk move --where "tags CONTAINS 'work'" --to "Work Project"
 
 **Safety options:**
 - `--dry-run` - Preview changes without applying them
-- `--limit N` - Maximum items to process (default: 50)
 - `--yes` - Skip confirmation prompts (use with caution)
+- `--list` - Specify which list to operate on (default: today)
 
-### 5. Statistics Dashboard
+### 6. Statistics Dashboard
 
 Track your productivity:
 
 ```bash
 clings stats              # Show dashboard
-clings stats --trends     # Completion trends over time
-clings stats --heatmap    # Activity heatmap calendar
+clings stats trends       # Completion trends over time
+clings stats heatmap      # Activity heatmap calendar
+clings stats --days 7     # Limit to last 7 days
 ```
 
-### 6. Weekly Review
+### 7. Weekly Review
 
 Guide yourself through a GTD-style weekly review:
 
 ```bash
-clings review              # Start a new review
-clings review --resume     # Resume paused review
-clings review --status     # Check progress
-```
-
-### 7. Terminal UI
-
-Launch the interactive terminal interface:
-
-```bash
-clings tui
-
-# Keybindings:
-# j/k or arrows  Navigate
-# c              Complete todo
-# x              Cancel todo
-# Enter          Open in Things
-# q/Esc          Quit
+clings review             # Start a new review (default)
+clings review start       # Same as above
+clings review status      # Show last review session info
+clings review clear       # Clear review session
 ```
 
 ### 8. Shell Completions
@@ -148,34 +177,7 @@ clings completions zsh > ~/.zfunc/_clings
 clings completions fish > ~/.config/fish/completions/clings.fish
 ```
 
-### 9. Todo Management
-
-Manage individual todos:
-
-```bash
-# Show todo details
-clings show <ID>
-
-# Update todo properties
-clings update <ID> --name "New title"
-clings update <ID> --notes "Updated notes"
-clings update <ID> --due 2024-12-25
-clings update <ID> --tags work,urgent
-
-# Schedule and organize (requires auth token, see Configuration)
-clings update <ID> --when tomorrow
-clings update <ID> --heading "Waiting on them"
-clings update <ID> --when today --heading "In Progress"
-
-# Mark as complete
-clings complete <ID>          # or: clings done <ID>
-
-# Cancel or delete
-clings cancel <ID>
-clings delete <ID>            # or: clings rm <ID>
-```
-
-### 10. Configuration
+### 9. Configuration
 
 Set up the Things 3 auth token for features that use the Things URL scheme (`--when`, `--heading`):
 
@@ -238,6 +240,9 @@ clings inbox
 # Search for tasks
 clings search "project"
 
+# Filter by status and date
+clings filter "due < today AND status = open"
+
 # Get productivity stats
 clings stats
 
@@ -267,22 +272,21 @@ clings add --help
 | `anytime` | - | Show anytime todos |
 | `someday` | `s` | Show someday todos |
 | `logbook` | `l` | Show completed todos |
-| `add` | `a` | Quick add with natural language |
+| `projects` | - | List all projects |
+| `areas` | - | List all areas |
+| `tags` | - | Manage tags |
 | `show` | - | Show details of a todo by ID |
+| `add` | - | Add a new todo with natural language |
 | `update` | - | Update a todo's properties |
 | `complete` | `done` | Mark a todo as completed |
 | `cancel` | - | Cancel a todo |
 | `delete` | `rm` | Delete a todo (moves to trash) |
 | `search` | `find`, `f` | Search todos by text |
-| `filter` | - | Filter todos using a query expression |
-| `projects` | - | List all projects |
-| `project` | - | Manage projects |
-| `areas` | - | List all areas |
-| `tags` | - | Manage tags |
-| `bulk` | - | Bulk operations on multiple todos |
+| `filter` | - | Filter todos using SQL-like expressions |
 | `open` | - | Open Things 3 to a view or item |
+| `bulk` | - | Bulk operations on multiple todos |
 | `stats` | - | View productivity statistics |
-| `review` | - | GTD weekly review workflow |
+| `review` | - | GTD weekly review workflow (start, status, clear) |
 | `config` | - | Configure clings settings (auth token) |
 | `completions` | - | Generate shell completions |
 


### PR DESCRIPTION
## Summary

Rewrites README to accurately reflect the actual CLI interface (v0.2.10). The previous README documented many commands and flags that don't exist.

See upstream PR for full details: https://github.com/dan-hart/clings/pull/4

## Changes
- Removed phantom commands: `clings list`, `clings todo`, `clings shell`, `clings tui`
- Fixed flag syntax: `stats trends` not `stats --trends`, `review start` not `review --resume`
- Corrected flag names: `--name` not `--title`, `--due` not `--deadline`
- Removed nonexistent search flags: `--tag`, `--project`, `--due`, `--filter`
- Added missing commands to reference table: `filter`, `config`, `show`
- Documented all review subcommands: start, status, clear
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/clings/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
