### PR TITLE
Update docs and gitignore for new infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ backup/
 
 # Braintrust sessions
 .braintrust/
+
+# Local docs and plans
+docs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,23 +46,21 @@ This approach provides:
 
 ```
 Sources/
-├── clings/
-│   └── main.swift           # Entry point
+├── ClingsCLI/
+│   └── Commands/              # Command implementations (AddCommand, ListCommands, etc.)
 ├── ClingsCore/
-│   ├── CLI/
-│   │   ├── Commands/        # Command implementations
-│   │   └── CLIApp.swift     # ArgumentParser setup
-│   ├── Database/
-│   │   └── ThingsDatabase.swift  # SQLite access
-│   ├── JXA/
-│   │   └── ThingsJXA.swift  # JXA script execution
-│   ├── Models/
-│   │   └── Todo.swift       # Data types
-│   ├── NLP/
-│   │   └── TaskParser.swift # Natural language parsing
-│   └── Output/
-│       ├── PrettyPrinter.swift
-│       └── JSONOutput.swift
+│   ├── Config/                # Auth token storage
+│   ├── Filter/                # Filter DSL parser and expression evaluator
+│   ├── Models/                # Todo, Project, Area, Tag, ChecklistItem, Status
+│   ├── NLP/                   # Natural language task parsing
+│   ├── Output/                # OutputFormatter (pretty + JSON)
+│   ├── ThingsClient/          # ThingsDatabase (SQLite), JXAScripts, HybridThingsClient
+│   └── Utils/                 # ThingsDateConverter, SchemaIntrospector
+Tests/
+├── ClingsCoreTests/
+│   ├── Database/              # ThingsDatabaseTests, SchemaDriftTests, TestDatabaseBuilder
+│   └── ThingsClient/          # JXAScriptsTests
+├── SchemaBaseline/            # schema-baseline.json (schema drift detection)
 ```
 
 ### Design Principles
@@ -136,41 +134,45 @@ import ClingsCore
 
 ## Testing Requirements
 
+### Database Path Resolution
+
+`ThingsDatabase` resolves its path in order:
+1. Explicit `databasePath` parameter (throws if file not found)
+2. `CLINGS_DB_PATH` environment variable (throws if file not found)
+3. Auto-discovery from Things 3 group container (falls back to JXA-only client)
+
 ### Test Categories
 
-**Unit Tests** - Test individual functions:
+**Unit Tests** - Test models, parsing, formatting:
 ```swift
-import XCTest
+import Testing
 @testable import ClingsCore
 
-final class TaskParserTests: XCTestCase {
-    func testParseDateTodayReturnsCurrentDate() {
+@Suite("TaskParser")
+struct TaskParserTests {
+    @Test func parseDateToday() {
         let result = TaskParser.parseDate("today")
-        XCTAssertEqual(result, Date().formatted(date: .numeric, time: .omitted))
+        #expect(result != nil)
     }
 }
 ```
 
-**Integration Tests** - Test CLI commands:
+**Database Integration Tests** - Test real SQLite queries using `TestDatabaseBuilder`:
 ```swift
-import XCTest
-
-final class CLIIntegrationTests: XCTestCase {
-    func testHelpFlagShowsUsage() throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: ".build/debug/clings")
-        process.arguments = ["--help"]
-
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        try process.run()
-        process.waitUntilExit()
-
-        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
-        XCTAssertTrue(output?.contains("Things 3") == true)
-    }
-}
+let builder = try TestDatabaseBuilder()
+DatabaseTestFixtures.populate(builder)
+let db = try ThingsDatabase(databasePath: builder.path)
+let todos = try db.fetchList(.today)
 ```
+
+`TestDatabaseBuilder` creates a temp SQLite file with the exact Things 3 schema (all 41 TMTask columns, plus TMArea, TMTag, TMTaskTag, TMAreaTag, TMChecklistItem). No live Things 3 installation needed.
+
+**Schema Drift Tests** - Compare live Things 3 DB against `Tests/SchemaBaseline/schema-baseline.json`. Auto-skip in CI via `XCTSkip` when Things 3 is not installed. Run locally with:
+```bash
+swift test --filter SchemaDrift
+```
+
+If Things 3 updates its schema, run `scripts/update-schema-baseline.sh` after verifying compatibility.
 
 ### Coverage Requirements
 
@@ -222,6 +224,7 @@ Commands:
   show                   Show details of a todo by ID
   add                    Quick add with natural language
   complete, done         Mark a todo as completed
+  reopen                 Reopen a completed/canceled todo
   cancel                 Cancel a todo
   delete, rm             Delete a todo
   update                 Update a todo's properties

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ clings filter "project IS NOT NULL"
 
 **Filter operators:** `=`, `!=`, `<`, `>`, `<=`, `>=`, `LIKE`, `CONTAINS`, `IS NULL`, `IS NOT NULL`, `IN`
 **Logic:** `AND`, `OR`
-**Fields:** `status`, `due`, `tags`, `project`, `area`, `name`, `notes`, `created`
+**Fields:** `status`, `due` / `deadline`, `tags`, `project`, `area`, `name`, `notes`, `created`, `startdate`, `recurring`
 
 ### 4. Todo Management
 
@@ -114,6 +114,7 @@ clings update <ID> --when today --heading "In Progress"
 # Complete, cancel, or delete
 clings complete <ID>             # or: clings done <ID>
 clings complete --title "milk"   # complete by title search
+clings reopen <ID>               # reopen a completed/canceled todo
 clings cancel <ID>
 clings delete <ID>               # or: clings rm <ID>
 clings delete <ID> --force       # skip confirmation
@@ -281,6 +282,7 @@ clings add --help
 | `add` | - | Add a new todo with natural language |
 | `update` | - | Update a todo's properties |
 | `complete` | `done` | Mark a todo as completed |
+| `reopen` | - | Reopen a completed/canceled todo |
 | `cancel` | - | Cancel a todo |
 | `delete` | `rm` | Delete a todo (moves to trash) |
 | `search` | `find`, `f` | Search todos by text |


### PR DESCRIPTION
## Summary

- Add `docs/` to `.gitignore` (local planning files)
- Update CLAUDE.md module structure to match actual codebase layout
- Add `reopen` command to CLAUDE.md and README.md
- Document database path resolution, TestDatabaseBuilder, and schema drift workflow in CLAUDE.md
- Add `startdate`, `recurring`, `deadline` filter fields to README.md

Housekeeping only, no code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/drewburchfield/clings/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
